### PR TITLE
Match Capital D as well

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ async function main() {
 
         rtm.on('message', (event) => {
             if (event.user === id && event.text) {
-                const matched = event.text.match(/^d*$/)
+                const matched = event.text.match(/^[dD]*$/)
 
                 if (matched) {
                     if (!event.thread_ts) {


### PR DESCRIPTION
On mobile, d is commonly changed into D with autocorrect. So, I added D to the RegExp.

No worries if you don't want to merge this so that it doesn't start deleting too many messages. 